### PR TITLE
feat: remove taggable presence check

### DIFF
--- a/lib/acts_as_taggable_on/tagging.rb
+++ b/lib/acts_as_taggable_on/tagging.rb
@@ -6,7 +6,7 @@ module ActsAsTaggableOn
 
     DEFAULT_CONTEXT = 'tags'
     belongs_to :tag, class_name: '::ActsAsTaggableOn::Tag', counter_cache: ActsAsTaggableOn.tags_counter
-    belongs_to :taggable, polymorphic: true
+    belongs_to :taggable, polymorphic: true, optional: true
 
     belongs_to :tagger, polymorphic: true, optional: true
 


### PR DESCRIPTION
The purpose of this is to be able to maintain a list of tags by context without assigning them to a model.

```ruby
ActsAsTaggableOn::Tagging.create!(
  tag_id: ActsAsTaggableOn::Tag.last.id,
  taggable_type: nil,
  taggable_id: nil,
  tagger_type: "Community",
  tagger_id: 1,
  context: "profile_groups",
)
=> #<ActsAsTaggableOn::Tagging:0x000056231caedd10
 id: 19,
 tag_id: 9,
 taggable_type: nil,
 taggable_id: nil,
 tagger_type: "Community",
 tagger_id: 1,
 context: "profile_groups",
 created_at: Thu, 30 Mar 2023 17:23:42.750791655 UTC +00:00>
```

```ruby
community.owned_tags
=>   ActsAsTaggableOn::Tag Load (3.0ms)  SELECT DISTINCT "coworks_tags".* FROM "coworks_tags" INNER JOIN "coworks_taggings" ON "coworks_tags"."id" = "coworks_taggings"."tag_id" WHERE "coworks_taggings"."tagger_id" = $1 AND "coworks_taggings"."tagger_type" = $2  [["tagger_id", 1], ["tagger_type", "Community"]]
[#<ActsAsTaggableOn::Tag:0x000056232252a878
  id: 1,
  name: "General",
  created_at: Wed, 01 Feb 2023 06:55:48.109105000 UTC +00:00,
  updated_at: Wed, 01 Feb 2023 06:55:48.109105000 UTC +00:00,
  taggings_count: 5>,
 #<ActsAsTaggableOn::Tag:0x000056232252a7b0
  id: 8,
  name: "Founders",
  created_at: Wed, 22 Mar 2023 19:50:25.420482000 UTC +00:00,
  updated_at: Wed, 22 Mar 2023 19:50:25.420482000 UTC +00:00,
  taggings_count: 2>,
 #<ActsAsTaggableOn::Tag:0x000056232252a6e8
  id: 9,
  name: "Space Pioneers",
  created_at: Wed, 22 Mar 2023 19:50:25.445150000 UTC +00:00,
  updated_at: Wed, 22 Mar 2023 19:50:25.445150000 UTC +00:00,
  taggings_count: 3>]
```